### PR TITLE
[codex] improve public issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_hq.yml
+++ b/.github/ISSUE_TEMPLATE/bug_hq.yml
@@ -1,0 +1,100 @@
+name: "🐞 X1 HQ bug report"
+description: Report a bug in the X1 HQ merchant back-office web app.
+title: "[Bug][X1 HQ]: "
+labels:
+  - needs-triage
+  - type:bug
+  - product:hq
+  - platform:web
+assignees:
+  - caterlord
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for bugs in X1 HQ, including dashboard, reports, menus, POS settings, store settings, online-ordering admin, integrations, and account/access flows.
+  - type: dropdown
+    id: area
+    attributes:
+      label: HQ area
+      description: Which part of X1 HQ is affected?
+      options:
+        - Dashboard
+        - Reports
+        - Menu Management
+        - POS Settings
+        - Store Settings
+        - Online Ordering Admin
+        - Integrations
+        - Account / Access / Login
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: page_url
+    attributes:
+      label: Page URL
+      description: Paste the exact X1 HQ page URL if available.
+      placeholder: https://hq.x1.tech/...
+  - type: input
+    id: browser
+    attributes:
+      label: Browser and version
+      placeholder: Chrome 135 / Safari 18 / Edge 135
+    validations:
+      required: true
+  - type: input
+    id: merchant_context
+    attributes:
+      label: Merchant context
+      description: Company, brand, shop, and user role if relevant.
+      placeholder: Testing Brand / Central Kitchen / Manager
+  - type: textarea
+    id: summary
+    attributes:
+      label: Issue summary
+      description: Clear, concise description of the problem.
+      placeholder: The new user signs in successfully but is sent to the dashboard instead of onboarding.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Use a numbered list and include any relevant setup data.
+      placeholder: |
+        1. Sign in to X1 HQ with a brand-new merchant account
+        2. Complete email verification
+        3. Observe the landing page after sign-in
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      placeholder: The user should be redirected to the onboarding flow.
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      placeholder: The user lands directly on the dashboard page.
+    validations:
+      required: true
+  - type: dropdown
+    id: impact
+    attributes:
+      label: Business impact
+      options:
+        - Critical - outage, data loss, or blocked operations
+        - High - major workflow broken
+        - Medium - workaround exists but painful
+        - Low - minor issue or cosmetic problem
+    validations:
+      required: true
+  - type: textarea
+    id: attachments
+    attributes:
+      label: Screenshots, video, or logs
+      description: Attach screenshots, recordings, console errors, or network traces. Remove customer data first.

--- a/.github/ISSUE_TEMPLATE/bug_online_ordering.yml
+++ b/.github/ISSUE_TEMPLATE/bug_online_ordering.yml
@@ -1,0 +1,90 @@
+name: "🐞 Online ordering bug report"
+description: Report a bug in the public online ordering storefront or checkout flow.
+title: "[Bug][Online Ordering]: "
+labels:
+  - needs-triage
+  - type:bug
+  - product:online-ordering
+assignees:
+  - caterlord
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for bugs in the customer-facing online ordering site, including menu browsing, cart, checkout, payments, and storefront localization.
+  - type: input
+    id: storefront_url
+    attributes:
+      label: Storefront URL
+      placeholder: https://order.x1.tech/your-brand
+    validations:
+      required: true
+  - type: dropdown
+    id: reporter_type
+    attributes:
+      label: Reporter type
+      options:
+        - Merchant
+        - Customer
+        - Internal staff
+    validations:
+      required: true
+  - type: input
+    id: device_browser
+    attributes:
+      label: Device and browser
+      placeholder: iPhone 16 / Safari 18, Windows 11 / Chrome 135
+    validations:
+      required: true
+  - type: input
+    id: order_context
+    attributes:
+      label: Order or checkout context
+      description: Include order ID, payment method, fulfillment mode, or promo code if relevant.
+      placeholder: Order 12345 / Pickup / Stripe / promo SAVE10
+  - type: textarea
+    id: summary
+    attributes:
+      label: Issue summary
+      placeholder: The checkout page shows a rounded total that does not match the cart.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Open the storefront
+        2. Add item A and item B
+        3. Go to checkout
+        4. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+  - type: dropdown
+    id: impact
+    attributes:
+      label: Business impact
+      options:
+        - Critical - outage, payment failure, or blocked ordering
+        - High - major ordering workflow broken
+        - Medium - workaround exists but painful
+        - Low - minor issue or cosmetic problem
+    validations:
+      required: true
+  - type: textarea
+    id: attachments
+    attributes:
+      label: Screenshots, video, or logs
+      description: Attach screenshots, recordings, or logs. Remove customer data and payment details.

--- a/.github/ISSUE_TEMPLATE/bug_pos.yml
+++ b/.github/ISSUE_TEMPLATE/bug_pos.yml
@@ -1,16 +1,17 @@
-name: "\U0001F41E Bug Report"
-description: Report a problem you encountered while using MobilePos.
-title: "[Bug]: "
+name: "🐞 POS app bug report"
+description: Report a bug in the POS app, customer display, or device runtime.
+title: "[Bug][POS]: "
 labels:
   - needs-triage
   - type:bug
+  - product:pos
 assignees:
   - caterlord
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to report a problem. Fill out every section so we can reproduce the issue quickly.
+        Use this form for point-of-sale app issues, including cashier flows, printing, table management, customer display, and device-specific behavior.
   - type: dropdown
     id: platform
     attributes:
@@ -20,6 +21,7 @@ body:
         - Desktop
         - Android
         - iOS
+        - Customer Display
         - Multiple
     validations:
       required: true
@@ -27,25 +29,28 @@ body:
     id: version
     attributes:
       label: App build number
-      description: The version shown on the About screen (for example `1.2.7 (build 456)`).
-      placeholder: 1.2.7 (build ###)
+      description: Version shown on the About screen or app settings page.
+      placeholder: 1.2.7 (build 456)
     validations:
       required: true
+  - type: input
+    id: store_terminal
+    attributes:
+      label: Store and terminal context
+      placeholder: Central Shop / Cashier 1 / Epson TM-m30III
   - type: textarea
     id: summary
     attributes:
       label: Issue summary
-      description: Clear, concise description of the problem.
-      placeholder: The order list fails to refresh after submitting payment...
+      placeholder: The order list fails to refresh after submitting payment.
     validations:
       required: true
   - type: textarea
     id: steps
     attributes:
       label: Steps to reproduce
-      description: Numbered list of steps. Include sample data or accounts if relevant.
       placeholder: |
-        1. Go to ...
+        1. Open ...
         2. Tap ...
         3. Observe ...
     validations:
@@ -64,18 +69,24 @@ body:
       placeholder: After checkout, the table remains in split mode and cannot be reused.
     validations:
       required: true
+  - type: dropdown
+    id: impact
+    attributes:
+      label: Business impact
+      options:
+        - Critical - outage, data loss, or blocked operations
+        - High - major workflow broken
+        - Medium - workaround exists but painful
+        - Low - minor issue or cosmetic problem
+    validations:
+      required: true
   - type: textarea
     id: environment
     attributes:
       label: Additional context
-      description: Environment details, related tickets, or anything else that helps triage.
-      placeholder: |
-        - POS hardware model:
-        - Network conditions:
-        - Recent changes or deployments:
+      description: Include hardware model, printer model, network conditions, or recent changes if relevant.
   - type: textarea
     id: attachments
     attributes:
-      label: Screenshots or logs
-      description: Drag in screenshots, screen recordings, or relevant log excerpts. Remove any customer data.
-      placeholder: Attach files or paste log snippets here.
+      label: Screenshots, video, or logs
+      description: Drag in screenshots, recordings, or relevant log excerpts. Remove customer data.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,11 @@
 blank_issues_enabled: false
 contact_links:
-  - name: MobilePos Support
+  - name: Urgent production support
     url: mailto:support@mobilepos.com
-    about: For urgent account or billing issues, email our support team directly.
+    about: For live production outages, payment failures, or urgent store-impacting issues, contact support directly.
+  - name: Account and billing support
+    url: mailto:support@mobilepos.com
+    about: For account access, billing, subscription, or merchant-admin issues, contact support directly.
+  - name: Security or responsible disclosure
+    url: mailto:support@mobilepos.com
+    about: Do not open public issues for security problems. Email the team directly instead.

--- a/.github/ISSUE_TEMPLATE/documentation_feedback.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_feedback.yml
@@ -1,8 +1,9 @@
 name: "\U0001F4DA Documentation feedback"
-description: Report problems, issues, suggestions, or requests for MobilePos online documentation.
+description: Report problems, issues, suggestions, or requests for X1 / MobilePos documentation.
 labels:
   - needs-triage
   - type:documentation
+  - product:docs
 assignees:
   - caterlord
 body:
@@ -11,6 +12,19 @@ body:
       value: |
         Use this form to report documentation problems or suggest improvements.
         Public documentation: https://docs.x1.tech
+  - type: dropdown
+    id: doc_area
+    attributes:
+      label: Documentation area
+      options:
+        - X1 HQ
+        - POS App
+        - Online Ordering
+        - Integrations
+        - General / Getting Started
+        - Other
+    validations:
+      required: true
   - type: dropdown
     id: feedback_type
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,5 @@
 name: "\U0001F4A1 Feature request"
-description: Suggest an improvement or new capability for MobilePos.
+description: Suggest an improvement or new capability for X1 / MobilePos.
 labels:
   - needs-triage
   - type:feature
@@ -15,11 +15,12 @@ body:
     attributes:
       label: Product area
       options:
-        - Point of Sale
-        - Table Management
-        - Menu Management
+        - X1 HQ
+        - POS App
+        - Online Ordering
         - Reporting
         - Integrations
+        - Documentation
         - Other
     validations:
       required: true
@@ -35,6 +36,31 @@ body:
     attributes:
       label: What problem does this solve?
       description: Explain the pain point or workflow challenge you are facing today.
+    validations:
+      required: true
+  - type: dropdown
+    id: audience
+    attributes:
+      label: Who is affected?
+      options:
+        - Store owner / merchant admin
+        - Cashier / frontline staff
+        - Customer ordering online
+        - Internal operations / support team
+        - Multiple groups
+    validations:
+      required: true
+  - type: dropdown
+    id: impact
+    attributes:
+      label: Business impact
+      options:
+        - Critical - blocking revenue or rollout
+        - High - major workflow gap
+        - Medium - useful improvement with clear value
+        - Low - nice to have
+    validations:
+      required: true
   - type: textarea
     id: workaround
     attributes:


### PR DESCRIPTION
## Summary
- split bug intake into dedicated forms for X1 HQ, POS app, and online ordering
- expand feature and documentation forms so they cover HQ, docs, and product context cleanly
- improve contact routing for urgent support, account and billing, and security disclosure

## Why
The old public issue form was POS-oriented and did not give merchants a clear way to report X1 HQ issues. It also referenced missing documentation labels and mixed platform concerns with product concerns.

This update makes issue intake product-specific and easier to triage:
- X1 HQ issues now have their own form
- POS app issues keep platform-specific fields
- online ordering issues have storefront and checkout-specific context
- docs and feature requests now capture product area and business impact better

## Additional GitHub Setup
The repository labels were also synced directly on GitHub to support the new forms:
- `type:documentation`
- `product:hq`
- `product:pos`
- `product:online-ordering`
- `product:docs`
- `product:integrations`
- `platform:web`

## Validation
- reviewed rendered issue-form YAML locally
- verified the public tracker label set now matches the form labels
