### PR TITLE
[codex] rename public bug forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_online_ordering.yml
+++ b/.github/ISSUE_TEMPLATE/bug_online_ordering.yml
@@ -1,6 +1,6 @@
-name: "🐞 Online ordering bug report"
+name: "🐞 X1 ODO bug report"
 description: Report a bug in the public online ordering storefront or checkout flow.
-title: "[Bug][Online Ordering]: "
+title: "[Bug][X1 ODO]: "
 labels:
   - needs-triage
   - type:bug

--- a/.github/ISSUE_TEMPLATE/bug_pos.yml
+++ b/.github/ISSUE_TEMPLATE/bug_pos.yml
@@ -1,6 +1,6 @@
-name: "🐞 POS app bug report"
+name: "🐞 X1 POS bug report"
 description: Report a bug in the POS app, customer display, or device runtime.
-title: "[Bug][POS]: "
+title: "[Bug][X1 POS]: "
 labels:
   - needs-triage
   - type:bug


### PR DESCRIPTION
## Summary
- rename the online ordering bug form to `X1 ODO bug report`
- rename the POS bug form to `X1 POS bug report`
- update the default issue title prefixes to match the new names

## Why
The public issue chooser should use the same product naming merchants already see elsewhere. `X1 ODO` and `X1 POS` are clearer and more consistent than the generic labels.

## Validation
- reviewed the issue-form YAML for the two renamed templates
