### PR TITLE
chore: align public feedback branding with X1

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation_feedback.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_feedback.yml
@@ -1,5 +1,5 @@
 name: "\U0001F4DA Documentation feedback"
-description: Report problems, issues, suggestions, or requests for X1 / MobilePos documentation.
+description: Report problems, issues, suggestions, or requests for X1 documentation.
 labels:
   - needs-triage
   - type:documentation

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,5 @@
 name: "\U0001F4A1 Feature request"
-description: Suggest an improvement or new capability for X1 / MobilePos.
+description: Suggest an improvement or new capability for X1.
 labels:
   - needs-triage
   - type:feature

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -8,4 +8,4 @@ By participating in this feedback repository, you agree to:
 - Provide constructive feedback; attack the issue, not the person.
 - Follow the GitHub Community Guidelines.
 
-Reports of abusive, harassing, or otherwise unacceptable behavior may be sent to support@mobilepos.com. The MobilePos team reserves the right to moderate, edit, or remove content that violates these guidelines.
+Reports of abusive, harassing, or otherwise unacceptable behavior may be sent to support@mobilepos.com. The X1 team reserves the right to moderate, edit, or remove content that violates these guidelines.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,11 +2,11 @@
 
 **Do not disclose potential security issues publicly.**
 
-If you believe you have found a vulnerability in any MobilePos product or service, please email `security@mobilepos.com` with the details. We will respond within two business days.
+If you believe you have found a vulnerability in any X1 product or service, please email `security@mobilepos.com` with the details. We will respond within two business days.
 
 When reporting, include:
 - A clear description of the vulnerability and the product version affected.
 - Steps to reproduce the issue.
 - Any proof-of-concept code or screenshots (if safe to share).
 
-We appreciate your help in keeping MobilePos customers safe.
+We appreciate your help in keeping X1 customers safe.


### PR DESCRIPTION
## Summary
- Replace remaining MobilePos-facing wording in feedback templates and public policy docs with X1 wording.
- Keep existing support and security contact addresses unchanged.

## Validation
- `git diff --check`