### PR TITLE
chore: ignore macOS metadata files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store


### PR DESCRIPTION
## Summary
- Add `.DS_Store` to the repository `.gitignore` so local macOS metadata files do not appear as untracked changes.

## Validation
- `git diff --check HEAD~1..HEAD`
- `git status --short` no longer reports `.DS_Store`